### PR TITLE
Introduce argparse for argument parsing

### DIFF
--- a/modelrepo_json.puml
+++ b/modelrepo_json.puml
@@ -1,4 +1,4 @@
-!$allelems = {"modelrepopath": "/Users/mvoss/Desktop/git/github/pumla_restructure/pumla", "modelrepofile": "./modelrepo_json.puml", "elements": [{"name": "pumla preprocessor macros", "alias": "pppm", "type": "rectangle", "stereotypes": ["PlantUML", "preprocessor macros"], "kind": "static", "parent": "pumla", "instclassalias": "-", "path": "./", "filename": "pumla_macros_arch.puml"},
+!$allelems = {"modelrepopath": "/Users/mvoss/Desktop/git/github/pumla_cl/pumla", "modelrepofile": "./modelrepo_json.puml", "elements": [{"name": "pumla preprocessor macros", "alias": "pppm", "type": "rectangle", "stereotypes": ["PlantUML", "preprocessor macros"], "kind": "static", "parent": "pumla", "instclassalias": "-", "path": "./", "filename": "pumla_macros_arch.puml"},
  {"name": "pumla", "alias": "pumla", "type": "", "stereotypes": ["application", "python"], "kind": "static", "parent": "-", "instclassalias": "-", "path": "./", "filename": "pumla.puml"},
  {"name": "model", "alias": "pumlaModel", "type": "rectangle", "stereotypes": ["module", "python"], "kind": "static", "parent": "pumla", "instclassalias": "-", "path": "./src/pumla/", "filename": "pumlaModel.puml"},
  {"name": "control", "alias": "pumlaControl", "type": "rectangle", "stereotypes": ["module", "python"], "kind": "static", "parent": "pumla", "instclassalias": "-", "path": "./src/pumla/", "filename": "pumlaControl.puml"},
@@ -7,7 +7,7 @@
  {"name": "PUMLAConnection.py", "alias": "pumlaConnection", "type": "class", "stereotypes": ["module", "python"], "kind": "static", "parent": "pumlaModel", "instclassalias": "-", "path": "./src/pumla/model/", "filename": "pumlaConnection.puml"},
  {"name": "cmd_utils.py", "alias": "cmdUtils", "type": "class", "stereotypes": ["module", "python"], "kind": "static", "parent": "pumlaControl", "instclassalias": "-", "path": "./src/pumla/control/", "filename": "cmdUtils.puml"}]}
 
-!$allrelations = {"modelrelationrepopath": "/Users/mvoss/Desktop/git/github/pumla_restructure/pumla", "modelrelationrepofile": "./modelrepo_json.puml", "relations": []}
+!$allrelations = {"modelrelationrepopath": "/Users/mvoss/Desktop/git/github/pumla_cl/pumla", "modelrelationrepofile": "./modelrepo_json.puml", "relations": []}
 
-!$allconnections = {"modelconnectionrepopath": "/Users/mvoss/Desktop/git/github/pumla_restructure/pumla", "modelconnectionrepofile": "./modelrepo_json.puml", "connections": []}
+!$allconnections = {"modelconnectionrepopath": "/Users/mvoss/Desktop/git/github/pumla_cl/pumla", "modelconnectionrepofile": "./modelrepo_json.puml", "connections": []}
 

--- a/pumla_UsersGuide.md
+++ b/pumla_UsersGuide.md
@@ -37,7 +37,7 @@ at the current folder location and traverses from here through all underlying
 folders for all `.puml` files. If you want to exclude certain folders from the search,
 you can name these in a `pumla_blacklist.txt` file. The .puml files found will be parsed and if they are 
 pumla files, their relevant content will be extracted and stored in the 
-`modelrepo_json.puml` (and tbd: `diagramrepo_json.puml`) file or the the given
+`modelrepo_json.puml` (and tbd: `diagramrepo_json.puml`) file or the given
 filename. Each call will overwrite the existing `{modelrepo | diagramrepo}_json.puml`
 files, therefore they should not be modified by hand,
 because changes will get lost. These repository files are the basis for the

--- a/src/pumla/main.py
+++ b/src/pumla/main.py
@@ -6,7 +6,7 @@ element re-usability.
 __author__ = "Dr. Markus Voss (private person)"
 __copyright__ = "(C) Copyright 2021 by Dr. Markus Voss (private person)"
 __license__ = "GPL"
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __maintainer__ = "Dr. Markus Voss (private person)"
 __status__ = "Development"
 
@@ -54,7 +54,7 @@ def cmd_update(args):
         print("failed.")
 
 
-def cmd_listfiles():
+def cmd_listfiles(args):
     print("all pumla files in subdirs:")
     pfls = findAllPUMLAFiles(os.path.curdir)
     for e in pfls:
@@ -69,13 +69,20 @@ def main():
     subparsers = parser.add_subparsers(
         title="Available commands",
         metavar="",
-        help="Call without command to list available `pumla` files.",
+        help="One of these commands must be used in order to execute pumla functionality:",
     )
     parser_listelements = subparsers.add_parser(
-        "listelements",
-        help="list all `pumla` model elements and diagrams of the model repository and diagram repository",
+        "elements",
+        help="list all `pumla` model elements of the model repository repository",
     )
     parser_listelements.set_defaults(func=cmd_listelements)
+
+    parser_listfiles = subparsers.add_parser(
+        "files",
+        help="list all `pumla` marked model files of the model repository",
+    )
+    parser_listfiles.set_defaults(func=cmd_listfiles)
+
     parser_update = subparsers.add_parser(
         "update",
         help="(re-)generate `modelrepo_json.puml` with updated info from `pumla` model elements found in repository.",
@@ -93,5 +100,5 @@ def main():
     try:
         args.func(args)
     except AttributeError:
-        # no parameter - default behaviour: show all pumla files in subdirs
-        cmd_listfiles()
+        # no parameter - default behaviour: show help
+        parser.print_help()

--- a/src/pumla/main.py
+++ b/src/pumla/main.py
@@ -10,64 +10,88 @@ __version__ = "0.8.0"
 __maintainer__ = "Dr. Markus Voss (private person)"
 __status__ = "Development"
 
-import sys
+import argparse
 import os
 from pumla.control.cmd_utils import findAllPUMLAFiles, parsePUMLAFile, updatePUMLAMR
 
-def identifyMe():
+
+def identifyMe(parser):
     """ information about the executed command """
-    print("pumla v0.8 - by Dr. Markus Voss")
+    print(parser.description)
 
-def parseSysArg(sysarg):
-    """ parses the given command line arguments """
-    # no parameter - default behaviour: show all pumla files in subdirs
-    if (len(sysarg) == 1):
-        print("all pumla files in subdirs:")
-        pfls = findAllPUMLAFiles(os.path.curdir)
-        for e in pfls:
-            print(e)
+
+def cmd_listelements(args):
+    print("\nPUMLA elements:\n")
+    # pfls = list of PUMLA files
+    pfls = findAllPUMLAFiles(os.path.curdir)
+
+    # pelems = list of PUMLA elements
+    pelems = []
+
+    # parse each PUMLA file
+    # and fill PUMLA elements list
+    for fn in pfls:
+        # pel = PUMLA element
+        (pels, rels, cons, tvs) = parsePUMLAFile(fn)
+        for pel in pels:
+            pelems.append(pel)
+
+    # print out the details of each
+    # element of the PUMLA elements list
+    for e in pelems:
+        e.printMe()
+        print("")
+
+
+def cmd_update(args):
+    """create/update/overwrite the pumla model repository"""
+    print("updating...")
+    (success, efn) = updatePUMLAMR(os.path.curdir, args.mrefilename)
+    if success:
+        print("model repo file: " + efn)
+        print("done.")
     else:
-        if (sysarg[1] == "listelements"):
-            print("\nPUMLA elements:\n")
-            # pfls = list of PUMLA files
-            pfls = findAllPUMLAFiles(os.path.curdir)
+        print("failed.")
 
-            # pelems = list of PUMLA elements
-            pelems = []
 
-            # parse each PUMLA file
-            # and fill PUMLA elements list
-            for fn in pfls:
-                # pel = PUMLA element
-                (pels, rels, cons, tvs) = parsePUMLAFile(fn)
-                for pel in pels:
-                    pelems.append(pel)
+def cmd_listfiles():
+    print("all pumla files in subdirs:")
+    pfls = findAllPUMLAFiles(os.path.curdir)
+    for e in pfls:
+        print(e)
 
-            # print out the details of each
-            # element of the PUMLA elements list
-            for e in pelems:
-                #print(e)
-                e.printMe()
-                print("")
-
-        elif (sysarg[1] == "update"):
-            print("updating...")
-            # if there is another command line argument after the update command...
-            if (len(sysarg) > 2):
-                # take 3rd command line argument as filename for model repo JSON file
-                mrefilename = sysarg[2]
-            else:
-                # setup the default filename to store the JSON model repo
-                mrefilename = os.path.curdir + "/modelrepo_json.puml"
-
-            # create/update/overwrite the pumla model repository
-            (success, efn) = updatePUMLAMR(os.path.curdir, mrefilename)
-            if (success):
-                print("model repo file: " + efn)
-                print("done.")
-            else:
-                print("failed.")
 
 def main():
-    identifyMe()
-    parseSysArg(sys.argv)
+    """ parses and executes the given command line arguments """
+    parser = argparse.ArgumentParser(
+        description=f"pumla v{__version__} - by {__author__}"
+    )
+    subparsers = parser.add_subparsers(
+        title="Available commands",
+        metavar="",
+        help="Call without command to list available `pumla` files.",
+    )
+    parser_listelements = subparsers.add_parser(
+        "listelements",
+        help="list all `pumla` model elements and diagrams of the model repository and diagram repository",
+    )
+    parser_listelements.set_defaults(func=cmd_listelements)
+    parser_update = subparsers.add_parser(
+        "update",
+        help="(re-)generate `modelrepo_json.puml` with updated info from `pumla` model elements found in repository.",
+    )
+    parser_update.add_argument(
+        "mrefilename",
+        help="filename for model repo JSON file",
+        nargs="?",
+        default=os.path.curdir + "/modelrepo_json.puml",
+    )
+    parser_update.set_defaults(func=cmd_update)
+
+    args = parser.parse_args()
+    identifyMe(parser)
+    try:
+        args.func(args)
+    except AttributeError:
+        # no parameter - default behaviour: show all pumla files in subdirs
+        cmd_listfiles()


### PR DESCRIPTION
This addresses #5. I am not 100% happy with the restructuring, but I tried to not change the user interface and keep it as is. 
The fact that passing no argument acts as it's own subcommand makes it hard to handle the argument parsing in a uniform way. 

- [x] Can we introduce a new command "listfiles"?
- [x] Are you ok with the wording? And adjustments?

The proposed implementation uses "subparsers" to handle the subcommand, as this allows to make the positional arguments optional (which wouldn't be allowed otherwise without making them flags starting with "--"). This has the benefit however, that e.g. `mrefilename` can be cleanly handled as an argument to a subcommand so that it is possible to read it's documentation when calling `pumla update --help`.
The "hacky" part, which is providing a default attribute `func` for each subcommand and executing it after parsing is actually taken from the [official documentation](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_subparsers). It just get's a little more verbose, because we need to handle the "no argument provided" usecase.

The final output of calling `pumla --help` now looks like this:
```
usage: pumla [-h]  ...

pumla v0.8.0 - by Dr. Markus Voss (private person)

optional arguments:
  -h, --help    show this help message and exit

Available commands:
                Call without command to list available `pumla` files.
    listelements
                list all `pumla` model elements and diagrams of the model repository and diagram repository
    update      (re-)generate `modelrepo_json.puml` with updated info from `pumla` model elements found in repository.
```

