### PR TITLE
Fix missing dependency to requests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
 packages = find:
 package_dir =
     =src
+install_requires =
+    requests
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Pumla depends on "requests", but isn't pulling it as a dependency.