### PR TITLE
fix bug when an elem have a relation with tags and other withour

### DIFF
--- a/pumla_macros_global.puml
+++ b/pumla_macros_global.puml
@@ -785,7 +785,7 @@ PUMLAInterface($ifname, $ifalias, $elemalias, $type)
         !endif
     !endfor
 
-    !if ((($el.start == $elemalias) || ($el.end == $elemalias)) && ($el.reltype  == $reltype))
+    !if ((($el.start == $elemalias) || ($el.end == $elemalias)) && ($el.reltype == $reltype) && (($tag == "") || ($tv_found == "YES")))
         ' make sure to not put the same relation twice
         !if (%not(%variable_exists($$el.id)))
             PUMLAPutRelation($el.id)

--- a/pumla_macros_global.puml
+++ b/pumla_macros_global.puml
@@ -762,6 +762,8 @@ PUMLAInterface($ifname, $ifalias, $elemalias, $type)
 ' to the diagram
 !unquoted procedure PUMLAPutRelationsForElement($elemalias, $reltype="", $tag="", $value="")
 !foreach $el in $allrelations.relations
+    !$tv_found = "NO"
+
     !if ($reltype == "")
         !$reltype = $el.reltype
     !endif


### PR DESCRIPTION
Using PUMLAPutRelationsForElement, if an element have a relation with the specified TAG, all the relation treated after and having no tag, will be displayed.
